### PR TITLE
[fix][client] PatternConsumer can't discovery new topic when broker disable pattern evaluation

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -44,8 +44,6 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.topics.TopicList;
-import org.apache.pulsar.common.util.Backoff;
-import org.apache.pulsar.common.util.BackoffBuilder;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,15 +55,6 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     private final CompletableFuture<TopicListWatcher> watcherFuture = new CompletableFuture<>();
     protected NamespaceName namespaceName;
 
-    /**
-     * There is two task to re-check topic changes, the both tasks will not be take affects at the same time.
-     * 1. {@link #recheckTopicsChangeAfterReconnect}: it will be called after the {@link TopicListWatcher} reconnected
-     *     if you enabled {@link TopicListWatcher}. This backoff used to do a retry if
-     *     {@link #recheckTopicsChangeAfterReconnect} is failed.
-     * 2. {@link #run} A scheduled task to trigger re-check topic changes, it will be used if you disabled
-     *     {@link TopicListWatcher}.
-     */
-    private final Backoff recheckPatternTaskBackoff;
     private final AtomicInteger recheckPatternEpoch = new AtomicInteger();
     private volatile Timeout recheckPatternTimeout = null;
     private volatile String topicsHash;
@@ -89,11 +78,6 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         this.topicsPattern = topicsPattern;
         this.topicsHash = topicsHash;
         this.subscriptionMode = subscriptionMode;
-        this.recheckPatternTaskBackoff = new BackoffBuilder()
-                .setInitialTime(client.getConfiguration().getInitialBackoffIntervalNanos(), TimeUnit.NANOSECONDS)
-                .setMax(client.getConfiguration().getMaxBackoffIntervalNanos(), TimeUnit.NANOSECONDS)
-                .setMandatoryStop(0, TimeUnit.SECONDS)
-                .create();
 
         if (this.namespaceName == null) {
             this.namespaceName = getNameSpaceFromPattern(topicsPattern);
@@ -102,23 +86,24 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
 
         this.topicsChangeListener = new PatternTopicsChangedListener();
         this.updateTaskQueue = new PatternConsumerUpdateQueue(this);
-        this.recheckPatternTimeout = client.timer()
-                .newTimeout(this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
         if (subscriptionMode == Mode.PERSISTENT) {
             long watcherId = client.newTopicListWatcherId();
             new TopicListWatcher(updateTaskQueue, client, topicsPattern, watcherId,
                 namespaceName, topicsHash, watcherFuture, () -> recheckTopicsChangeAfterReconnect());
             watcherFuture
-               .thenAccept(__ -> recheckPatternTimeout.cancel())
                .exceptionally(ex -> {
                    log.warn("Pattern consumer [{}] unable to create topic list watcher. Falling back to only polling"
                            + " for new topics", conf.getSubscriptionName(), ex);
+                   this.recheckPatternTimeout = client.timer().newTimeout(
+                           this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
                    return null;
                });
         } else {
             log.debug("Pattern consumer [{}] not creating topic list watcher for subscription mode {}",
                     conf.getSubscriptionName(), subscriptionMode);
             watcherFuture.complete(null);
+            this.recheckPatternTimeout = client.timer().newTimeout(
+                    this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
         }
     }
 
@@ -155,7 +140,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                 // If "recheckTopicsChange" has been called more than one times, only make the last one take affects.
                 // Use "synchronized (recheckPatternTaskBackoff)" instead of
                 // `synchronized(PatternMultiTopicsConsumerImpl.this)` to avoid locking in a wider range.
-                synchronized (recheckPatternTaskBackoff) {
+                synchronized (PatternMultiTopicsConsumerImpl.this) {
                     if (recheckPatternEpoch.get() > epoch) {
                         return CompletableFuture.completedFuture(null);
                     }
@@ -172,6 +157,11 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                     final List<String> oldTopics = new ArrayList<>(getPartitions());
                     return updateSubscriptions(topicsPattern, this::setTopicsHash, getTopicsResult,
                             topicsChangeListener, oldTopics, subscription);
+                }
+            }).thenAccept(__ -> {
+                if (recheckPatternTimeout != null) {
+                    this.recheckPatternTimeout = client.timer().newTimeout(
+                            this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
                 }
             });
     }
@@ -417,6 +407,11 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     @VisibleForTesting
     Timeout getRecheckPatternTimeout() {
         return recheckPatternTimeout;
+    }
+
+    @VisibleForTesting
+    int getRecheckPatternEpoch() {
+        return recheckPatternEpoch.get();
     }
 
     protected void handleSubscribeOneTopicError(String topicName,


### PR DESCRIPTION
### Motivation

If EnableBrokerSideSubscriptionPatternEvaluation=false of the broker side, the pattern can't discovery newly created topic.

This regression is introduced by #xxx and #xxx. those PR removed codes: https://github.com/apache/pulsar/pull/22854/files#diff-779a47f80b0048bab183870ed4c1ecd07ffd538006cf9358e494bee23405d924L154-L159

### Modifications

- when watcherFuture return exception, rollback to poll mode check topics.
- remove `recheckPatternTaskBackoff ` because it never used and it no match user side config: `patternAutoDiscoveryPeriod`

### Verifying this change
You can run `testSubscribePatterBrokerDisable` to reproduce this issue.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
